### PR TITLE
Add kernel density estimates for naive bayes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@ NaiveBayes.jl
 
 [![Build Status](https://travis-ci.org/dfdx/NaiveBayes.jl.svg)](https://travis-ci.org/dfdx/NaiveBayes.jl)
 
-Naive Bayes classifier. Currently 2 types of NB are supported: 
+Naive Bayes classifier. Currently 3 types of NB are supported:
 
- * **MultinomialNB** - assumes variables have a multinomial distribution. Good e.g. for text classification. See `examples/nums.jl` for usage.
- * **GaussianNB** - assumes variables have a multivariate normal distribution. Good for real-valued data. See `examples/iris.jl` for usage.
+ * **MultinomialNB** - Assumes variables have a multinomial distribution. Good for text classification. See `examples/nums.jl` for usage.
+ * **GaussianNB** - Assumes variables have a multivariate normal distribution. Good for real-valued data. See `examples/iris.jl` for usage.
+ * **KernelNB** - Computes kernel density estimates for each class. Good for data with continuous distributions.
 
-Since `GaussianNB` models multivariate distribution, it's not really a "naive" classifier (i.e. no independence assumption is made), so the name may change in the future. 
+Since `GaussianNB` models multivariate distribution, it's not really a "naive" classifier (i.e. no independence assumption is made), so the name may change in the future.
 
-As a subproduct, this package also provides a `DataStats` type that may be used for incremental calculation of common data statistics such as mean and covariance matrix. See `test/datastatstest.jl` for a usage example. 
+As a subproduct, this package also provides a `DataStats` type that may be used for incremental calculation of common data statistics such as mean and covariance matrix. See `test/datastatstest.jl` for a usage example.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.4
 Distributions 0.6+
+KernelDensity
+Grid

--- a/examples/iris.jl
+++ b/examples/iris.jl
@@ -1,7 +1,9 @@
 
 using NaiveBayes
 using RDatasets
+using StatsBase
 
+# Example 1
 iris = dataset("datasets", "iris")
 
 # observations in columns and variables in rows
@@ -21,5 +23,14 @@ model = GaussianNB(unique(y), p)
 fit(model, X[:, train], y[train])
 
 accuracy = countnz(predict(model, X[:,test]) .== y[test]) / countnz(test)
+println("Accuracy: $accuracy")
 
+# Example 2
+# 3 classes and 100 random data samples with 5 variables.
+n_obs = 100
+m = GaussianNB([:a, :b, :c], 5)
+X = randn(5, n_obs)
+y = sample([:a, :b, :c], n_obs)
+fit(m, X, y)
+accuracy = sum(predict(m, X) .== y) / n_obs
 println("Accuracy: $accuracy")

--- a/src/NaiveBayes.jl
+++ b/src/NaiveBayes.jl
@@ -1,9 +1,13 @@
 
 module NaiveBayes
 
+using KernelDensity
+using Grid
+
 export NBModel,
        MultinomialNB,
        GaussianNB,
+       KernelNB,
        fit,
        predict,
        predict_proba,

--- a/src/core.jl
+++ b/src/core.jl
@@ -239,3 +239,9 @@ end
 function predict(m::KernelNB, X)
    return [k for (k,v) in predict_proba(m, X)]
 end
+
+# TODO remove this once KernelDensity.jl pull request #27 is merged/tagged.
+function KernelDensity.InterpKDE{IT<:Grid.InterpType}(k::UnivariateKDE, bc::Number, it::Type{IT}=InterpQuadratic)
+    g = CoordInterpGrid(k.x, k.density, bc, it)
+    InterpKDE(k, g)
+end

--- a/src/datastats.jl
+++ b/src/datastats.jl
@@ -2,10 +2,10 @@
 using Base.BLAS
 
 # type for collecting data statistics incrementally
-type DataStats    
+type DataStats
     x_sums::Vector{Float64}      # sum(x_i)
     cross_sums::Matrix{Float64}  # sum(x_i'*x_i) (lower-triangular matrix)
-    n_obs::Uint64                # number of observations
+    n_obs::UInt64                # number of observations
     obs_axis::Int64              # observation axis, e.g. size(X, obs_axis)
                                  # should return number of observations
     function DataStats(n_vars, obs_axis=1)
@@ -44,5 +44,3 @@ function Base.cov(dstats::DataStats)
     Base.LinAlg.copytri!(C, 'L')
     return C
 end
-
-

--- a/src/nbtypes.jl
+++ b/src/nbtypes.jl
@@ -75,3 +75,27 @@ end
 function Base.show(io::IO, m::GaussianNB)
     print(io, "GaussianNB($(m.c_counts))")
 end
+
+#####################################
+#####  Kernel Naive Bayes       #####
+#####################################
+
+immutable KernelNB{C}
+    c_kdes::Dict{C, Vector{InterpKDE}}
+    n_vars::Int
+end
+
+function KernelNB{C}(classes::Vector{C}, n_vars::Int)
+    classes = unique(classes)
+    c_kdes = Dict{C, Vector{InterpKDE}}()
+    for class in classes
+        c_kdes[class] = Vector{InterpKDE}(n_vars)
+    end
+    KernelNB{C}(c_kdes, n_vars)
+end
+
+function Base.show(io::IO, m::KernelNB)
+    println(io, "KernelNB")
+    println(io, "  Classes = $(keys(m.c_kdes))")
+    print(io, "  Number of variables = $(m.n_vars)")
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,30 @@
+@testset "Core Functions" begin
+    # 6 data samples with 2 variables belonging to 2 classes
+    X = [-1.0 -2.0 -3.0 1.0 2.0 3.0;
+         -1.0  -1.0 -2.0 1.0 1.0 2.0]
+    y = [1, 1, 1, 2, 2, 2]
+
+    @testset "Multinomial NB" begin
+        m = MultinomialNB([:a, :b, :c], 5)
+        X1 = [1 2 5 2;
+             5 3 -2 1;
+             0 2 1 11;
+             6 -1 3 3;
+             5 7 7 1]
+        y1 = [:a, :b, :a, :c]
+        fit(m, X1, y1)
+        @test predict(m, X1) == y1
+    end
+
+    @testset "Gaussian NB" begin
+        m = GaussianNB(unique(y), 2)
+        fit(m, X, y)
+        @test predict(m, X) == y
+    end
+
+    @testset "KDE NB" begin
+        m = KernelNB(y, 2)
+        fit(m, X, y)
+        @test predict(m, X) == y
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,35 +1,11 @@
 
-using StatsBase
 using NaiveBayes
 
-function test_multinomial()
-    print("testing MultinomialNB... ")
-    m = MultinomialNB([:a, :b, :c], 5)
-    X = [1 2 5 2;
-         5 3 -2 1;
-         0 2 1 11;
-         6 -1 3 3;
-         5 7 7 1]
-    y = [:a, :b, :a, :c]
-    
-    fit(m, X, y)
-    @assert predict(m, X) == y
-    println("OK")
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
 end
 
-function test_gaussian()
-    print("testing GaussianNB... ")
-    n_obs = 100
-    m = GaussianNB([:a, :b, :c], 5)
-    X = randn(5, n_obs)
-    y = sample([:a, :b, :c], n_obs)
-    
-    fit(m, X, y)
-    accuracy = sum(predict(m, X) .== y) / n_obs
-    println(accuracy)
-    println("OK")
-end
-
-
-test_multinomial()
-test_gaussian()
+include("core.jl")


### PR DESCRIPTION
- Add a new method `KernelNB()` which computes Kernel Density Estimates using `KernelDensity.jl`
- Standardises  tests for other NB methods
