### PR TITLE
Bugfix in core.jl

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -16,7 +16,7 @@ end
 
 
 function logprob_c{C}(m::NBModel, c::C)
-    return m.c_counts[c] / m.n_obs
+    return log(m.c_counts[c] / m.n_obs)
 end
 
 """Predict log probabilities for all classes"""


### PR DESCRIPTION
There seem to be a small bug in core.jl `logprob_c{C}(m::NBModel, c::C)` since it doesn't actually computes the log.
