### PR TITLE
Update to KernelDensity 0.3.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
-Distributions 0.6
+Distributions
 HDF5
-KernelDensity 0.2.0 0.3.0
-Grid
+Interpolations
+KernelDensity 0.3.0
 StatsBase

--- a/src/NaiveBayes.jl
+++ b/src/NaiveBayes.jl
@@ -3,11 +3,11 @@ module NaiveBayes
 using Distributions
 using HDF5
 using KernelDensity
-using Grid
+using Interpolations
 using StatsBase
 import StatsBase: fit, predict
 
-export NBModel,
+export  NBModel,
         MultinomialNB,
         GaussianNB,
         KernelNB,

--- a/test/core.jl
+++ b/test/core.jl
@@ -72,10 +72,13 @@ end
         @test all(y_h .== labels[end-Np:end])
 
         mkdir("tmp")
-        write_model(model, "tmp/test.h5")
-        m2 = load_model("tmp/test.h5")
-        rm("tmp", recursive=true)
-        compare_models!(model, m2)
+        try
+            write_model(model, "tmp/test.h5")
+            m2 = load_model("tmp/test.h5")
+            compare_models!(model, m2)
+        finally
+            rm("tmp", recursive=true)
+        end
 
 
         #testing reading and writing the model file with Symbols
@@ -84,10 +87,13 @@ end
         @test all(predict(m3, X) .== y)
 
         mkdir("tmp")
-        write_model(m3, "tmp/test.h5")
-        m4 = load_model("tmp/test.h5")
-        rm("tmp", recursive=true)
-        compare_models!(m3, m4)
+        try
+            write_model(m3, "tmp/test.h5")
+            m4 = load_model("tmp/test.h5")
+            compare_models!(m3, m4)
+        finally
+            rm("tmp", recursive=true)
+        end
     end
 
     @testset "Restructure features" begin


### PR DESCRIPTION
`KernelDensity.jl` (v0.3.0) uses `Interpolations.jl` instead of `Grid.jl`. 