### PR TITLE
Bump compatibility requirements for HDF5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.23.12, 0.24"
-HDF5 = "^0.12.5"
+HDF5 = "^0.14,^0.15"
 Interpolations = "^0.12.10"
 KernelDensity = "^0.6.0"
 StatsBase = "^0.33.1"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ HDF5 = "^0.14,^0.15"
 Interpolations = "^0.12.10"
 KernelDensity = "^0.6.0"
 StatsBase = "^0.33.1"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/hybrid.jl
+++ b/src/hybrid.jl
@@ -162,17 +162,17 @@ function write_model(model::HybridNB, filename::S) where {S <: AbstractString}
         @info("Writing a model with names of type $name_type")
         f["Labels"] = model.classes
         for c in model.classes
-            grp = g_create(f, "$c")
+            grp = create_group(f, "$c")
             grp["Prior"] = model.priors[c]
-            sub = g_create(grp, "Discrete")
+            sub = create_group(grp, "Discrete")
             for (name, discrete) in model.c_discrete[c]
-                f_grp = g_create(sub, "$name")
+                f_grp = create_group(sub, "$name")
                 f_grp["range"] = collect(keys(discrete.pairs))
                 f_grp["probability"] = collect(values(discrete.pairs))
             end
-            sub = g_create(grp, "Continuous")
+            sub = create_group(grp, "Continuous")
             for (name, continuous) in model.c_kdes[c]
-                f_grp = g_create(sub, "$name")
+                f_grp = create_group(sub, "$name")
                 f_grp["x"] = collect(continuous.kde.x)
                 f_grp["density"] = collect(continuous.kde.density)
             end


### PR DESCRIPTION
The old version is causing problems in MLJ, for example.

 This pull request also **bumps the version for Julia to 1.3** because the new versions of HDF5 require Julia 1.3.

@dfdx 