### PR TITLE
Bump [compat] for Interpolations.jl

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distributions = "0.23.12, 0.24"
 HDF5 = "^0.14,^0.15"
-Interpolations = "^0.12.10"
+Interpolations = "^0.12.10, ^0.13.1"
 KernelDensity = "^0.6.0"
 StatsBase = "^0.33.1"
 julia = "1.3"


### PR DESCRIPTION
This PR also adds CompatHelper to .github/workflows. To work, ssh key must be set up.

@dfdx Can you do this? You need to add a secret key and matching deployment key : https://github.com/JuliaRegistries/CompatHelper.jl#122-instructions-for-setting-up-the-ssh-deploy-key



